### PR TITLE
Fix Google Play Edition description wording

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -530,7 +530,7 @@
   {
     "dateClose": "2015-01-01",
     "dateOpen": "2014-05-01",
-    "description": "Google Play Edition was a type of an Android smartphones that Google sold.",
+    "description": "The Google Play Edition devices were a series of Android smartphones and tablets sold by Google.",
     "link": "https://arstechnica.com/gadgets/2015/01/dont-cry-for-the-google-play-edition-program-it-was-already-dead/",
     "name": "Google Play Edition",
     "type": "hardware"


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/List_of_Google_Play_edition_devices